### PR TITLE
Added content type negotiation using headers

### DIFF
--- a/src/nap.js
+++ b/src/nap.js
@@ -8,8 +8,8 @@ nap.web = newWeb
 nap.negotiate = { 
   selector : bySelector
 , ordered  : byOrdered
-, method   : byComparator(methodComparator)
-, accept   : byComparator(acceptTypeComparator)
+, method   : byComparator("Method", methodComparator)
+, accept   : byComparator("Accept-type", acceptTypeComparator)
 , invoke   : invoke
 }
 
@@ -111,12 +111,12 @@ function acceptTypeComparator(req, acceptType) {
   return req.headers.accept == acceptType
 }
 
-function byComparator(comparator){
+function byComparator(name, comparator){
   return function(map){
 
     var order = Object.keys(map)
       .map(function(key){
-        return handleKey(key, map[key], comparator)
+        return handleKey(key, map[key], comparator, name)
       })
 
     return function(req, res){
@@ -126,13 +126,13 @@ function byComparator(comparator){
   }
 }
 
-function handleKey(key, fn, matches){
+function handleKey(key, fn, matches, name){
   return function(req, res){
     if(matches(req, key)){
       invoke(this, fn, req, res)
       return
     }
-    res("Not Supported")
+    res(name + " Not Supported")
   }
 }
 

--- a/test/test.nap.js
+++ b/test/test.nap.js
@@ -101,6 +101,18 @@ describe("Nap", function(){
 
       expect(request.method).to.equal("get")
     })
+    it("be default requests have accept type of 'html'", function(){
+      var web = nap.web()
+        , request
+
+      web.resource("/yo", function(req){
+        request = req
+      })
+
+      web.req("/yo")
+
+      expect(request.headers.accept).to.equal("html")
+    })
   })
   describe("web.uri", function(){
     it("should generate a uri based on a named resource", function(){
@@ -247,6 +259,60 @@ describe("Nap", function(){
         web.req({ uri: "/sausage", method : "send" })
 
         spy.should.have.been.calledTwice
+      })
+    })
+    describe("negotiate.accept", function(){
+      it("should only accept accept-types where handlers are provided", function(){
+        var web = nap.web()
+          , spy = sinon.spy()
+
+        web.resource("/sausage" , nap.negotiate.accept({html : spy}))
+
+        web.req("/sausage")
+        web.req({ uri: "/sausage" })
+        web.req({ uri: "/sausage", headers : { accept : "html" } })
+        web.req({ uri: "/sausage", headers : { accept : "json" } })
+
+        spy.should.have.been.calledThrice
+      })
+    })
+    describe("negotiate.accept.method", function(){
+      it("should negotiate accept-type and method", function(){
+        var web = nap.web()
+          , getDataSpy = sinon.spy()
+          , sendDataSpy = sinon.spy()
+          , getViewSpy = sinon.spy()
+          , sendViewSpy = sinon.spy()
+
+        web.resource(
+          "/sausage" 
+        , nap.negotiate.accept(
+            { 
+              json : nap.negotiate.method(
+                { 
+                  get : getDataSpy 
+                , send : sendDataSpy 
+                }
+              ) 
+            , html : nap.negotiate.method(
+                { 
+                  get : getViewSpy 
+                , send : sendViewSpy 
+                }
+              ) 
+            }
+          )
+        )
+
+        web.req({ uri: "/sausage", headers : { accept : "json" } })
+        web.req({ uri: "/sausage", headers : { accept : "html" } })
+        web.req({ uri: "/sausage", headers : { accept : "json" } , method : "send" })
+        web.req({ uri: "/sausage", headers : { accept : "html" } , method : "send" })
+
+        getDataSpy.should.have.been.calledOnce
+        getViewSpy.should.have.been.calledOnce
+        sendViewSpy.should.have.been.calledOnce
+        sendViewSpy.should.have.been.calledOnce
       })
     })
   })

--- a/test/test.nap.js
+++ b/test/test.nap.js
@@ -286,18 +286,18 @@ describe("Nap", function(){
 
         web.resource(
           "/sausage" 
-        , nap.negotiate.accept(
+        , nap.negotiate.method(
             { 
-              json : nap.negotiate.method(
+              get : nap.negotiate.accept(
                 { 
-                  get : getDataSpy 
-                , send : sendDataSpy 
+                  html : getViewSpy 
+                , json : getDataSpy 
                 }
               ) 
-            , html : nap.negotiate.method(
+            , send : nap.negotiate.accept(
                 { 
-                  get : getViewSpy 
-                , send : sendViewSpy 
+                  html : sendViewSpy 
+                , json : sendDataSpy 
                 }
               ) 
             }


### PR DESCRIPTION
Implemented the same way as method negotiation. Not sure if the default accept type should be 'html' or 'view' or something else.
Specifying the accept-type as HTML would seem to imply that the resource should respond with an HTML representation. As views are free to respond or not, maybe this is misleading..
